### PR TITLE
Fix Mongoose search injection in login flow

### DIFF
--- a/controllers/main.js
+++ b/controllers/main.js
@@ -95,7 +95,7 @@ exports.getLogin = (req, res, next) => {
 
 //user login controller
 exports.postLogin = (req, res, next) => {
-  const email = req.body.email;
+  const email = typeof req.body.email === 'string' ? req.body.email : '';
   const password = req.body.password;
 
   const errors = validationResult(req);
@@ -112,7 +112,7 @@ exports.postLogin = (req, res, next) => {
     });
   }
 
-  User.findOne({ email: email })
+  User.findOne({ email: { $eq: email } })
     .then(user => {
       if (!user) {
         return res.status(422).render('auth/signup', {


### PR DESCRIPTION
### Motivation
- Prevent malicious query/operator injection via the login `email` field by ensuring only a string value is used in the Mongo lookup in `controllers/main.js`.

### Description
- Coerce `req.body.email` to a string (`const email = typeof req.body.email === 'string' ? req.body.email : ''`) and change the lookup to an explicit equality query (`User.findOne({ email: { $eq: email } })`) in `controllers/main.js`.

### Testing
- Committed the patch and verified the diff touches only `controllers/main.js`; attempting a quick module load with `node -e "require('./controllers/main'); ..."` failed due to a missing `express-validator/check` module in this environment, so no runtime tests could complete.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6987b5640d54832bb9bea5a42338fd0a)