### PR TITLE
chore: bump vulnerable npm deps and add overrides

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,24 +11,38 @@
   "author": "solomon",
   "license": "ISC",
   "devDependencies": {
-    "nodemon": "^1.18.3"
+    "nodemon": "^3.1.9"
   },
   "dependencies": {
     "bcryptjs": "^2.4.3",
-    "body-parser": "^1.18.3",
+    "body-parser": "^1.20.3",
     "connect-flash": "^0.1.1",
     "connect-mongodb-session": "^2.0.3",
     "csurf": "^1.9.0",
     "dotenv": "^16.0.3",
     "ejs": "^3.1.10",
-    "express": "^4.16.3",
-    "express-session": "^1.15.6",
+    "express": "^4.21.2",
+    "express-session": "^1.18.1",
     "express-validator": "^7.3.1",
     "mongoose": "^6.13.6",
     "node-fetch": "^2.6.9",
-    "nodemailer": "^4.6.8"
+    "nodemailer": "^6.10.1"
   },
   "engines": {
     "node": ">=14"
+  },
+  "overrides": {
+    "qs": "^6.14.1",
+    "lodash": "^4.17.23",
+    "fast-xml-parser": "^5.3.6",
+    "cookie": "^0.7.0",
+    "on-headers": "^1.1.0",
+    "path-to-regexp": "^0.1.10",
+    "send": "^0.19.0",
+    "serve-static": "^1.16.0",
+    "braces": "^3.0.3",
+    "got": "^11.8.5",
+    "mpath": "^0.8.4",
+    "lodash.set": "npm:@lodash/set@^4.3.3"
   }
 }


### PR DESCRIPTION
### Motivation
- Address security alerts by upgrading direct dependency ranges and forcing patched transitive versions for packages flagged in the security digest.

### Description
- Updated direct dependency ranges in `package.json` for `express` to `^4.21.2`, `body-parser` to `^1.20.3`, `express-session` to `^1.18.1`, `nodemailer` to `^6.10.1`, and bumped dev `nodemon` to `^3.1.9`.
- Added an `overrides` section in `package.json` to pin safe transitive versions for `qs`, `lodash`, `fast-xml-parser`, `cookie`, `on-headers`, `path-to-regexp`, `send`, `serve-static`, `braces`, `got`, `mpath`, and `lodash.set` (using `npm:@lodash/set`).
- Did not modify `package-lock.json` in this environment because lockfile regeneration could not complete here due to registry/network restrictions.

### Testing
- Confirmed the `overrides` block presence with `node -e "const p=require('./package.json'); console.log(Object.keys(p.overrides).length)"`, which returned the expected count.
- Attempted `npm install` and `npm install --package-lock-only` to regenerate the lockfile, but both failed with `403 Forbidden` from `registry.npmjs.org` due to proxy/network restrictions in this environment.
- Recommend running `npm install` in a network-enabled environment and committing the updated `package-lock.json` to fully apply and verify all transitive patches.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699dbbcd421c832bb217afc7aa723b24)